### PR TITLE
adding migration guide to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ package = external
 package_env = .ext
 commands =
     python -c 'from some_package import do; do()'
+
 [testenv:.ext]
 deps = build
 package_glob =


### PR DESCRIPTION
A follow-up to https://github.com/tox-dev/tox/pull/2235
Just adds a small migration guide to the readme.
Please, point out if I missed something, or if I made a mistake.